### PR TITLE
feat: add local docker POC setup with Service Bus emulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
 # Integration Hub POC
 
 Proof of concept for DHCW Integration Hub.
+
+## Running the POC locally
+View the [README](./local/README.md) inside the `/local` directory for instructions on how to run the POC locally.
+

--- a/local/.env
+++ b/local/.env
@@ -1,0 +1,5 @@
+# Environment file for user defined variables in docker-compose.yml
+
+CONFIG_PATH="./ServiceBusEmulatorConfig.json"
+ACCEPT_EULA="Y"
+MSSQL_SA_PASSWORD: "&z9xT0w99W(+"

--- a/local/README.md
+++ b/local/README.md
@@ -1,0 +1,40 @@
+# Running the POC locally
+
+## Prerequisites
+
+- Docker
+    - [Docker Desktop](https://docs.docker.com/desktop/install/windows-install/#:~:text=Install%20Docker%20Desktop%20on%20Windows%201%20Download%20the,on%20your%20choice%20of%20backend.%20...%20More%20items)
+- Minimum hardware Requirements:
+    - 2 GB RAM
+    - 5 GB of Disk space
+- WSL Enablement (Only for Windows):
+    - [Install Windows Subsystem for Linux (WSL) | Microsoft Learn](https://learn.microsoft.com/en-us/windows/wsl/install)
+    - [Configure Docker to use WSL](https://docs.docker.com/desktop/wsl/#:~:text=Turn%20on%20Docker%20Desktop%20WSL%202%201%20Download,engine%20..%20...%206%20Select%20Apply%20%26%20Restart.)
+
+    
+### Windows
+
+Before starting the stack, we need to allow execution of unsigned scripts. Run the below command in the PowerShell window:
+
+`$>Start-Process powershell -Verb RunAs -ArgumentList 'Set-ExecutionPolicy Bypass –Scope CurrentUser’`
+
+## Staring the stack
+After completing the prerequisites, you can proceed with the following command in the `/local` directory to run the POC locally:
+
+`docker compose up -d`
+
+## Interact with the Azure service bus emulator
+
+By default, emulator uses [ServiceBusEmulatorConfig.json](./ServiceBusEmulatorConfig.json) configuration file. You can configure entities by making changes to configuration file. To know more, visit [make configuration changes](https://learn.microsoft.com/en-us/azure/service-bus-messaging/overview-emulator#quota-configuration-changes).
+
+You can use the following connection string to connect to the Service Bus emulator:
+
+- When the emulator container and interacting application are running natively on local machine, use following connection string:
+```
+"Endpoint=sb://127.0.0.1;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;"
+```
+
+## Stopping the stack
+To terminate the containers you can proceed with the following command in the `/local` directory:
+
+`docker compose down`

--- a/local/ServiceBusEmulatorConfig.json
+++ b/local/ServiceBusEmulatorConfig.json
@@ -1,0 +1,53 @@
+{
+  "UserConfig": {
+    "Namespaces": [
+      {
+        "Name": "sbemulatorns",
+        "Queues": [
+          {
+            "Name": "dhcw-integration-hub-poc-docker-ingress",
+            "Properties": {
+              "DeadLetteringOnMessageExpiration": false,
+              "DefaultMessageTimeToLive": "PT1H",
+              "DuplicateDetectionHistoryTimeWindow": "PT20S",
+              "ForwardDeadLetteredMessagesTo": "",
+              "ForwardTo": "",
+              "LockDuration": "PT1M",
+              "MaxDeliveryCount": 3,
+              "RequiresDuplicateDetection": false,
+              "RequiresSession": false
+            }
+          }
+        ],
+
+        "Topics": [
+          {
+            "Name": "topic.1",
+            "Properties": {
+              "DefaultMessageTimeToLive": "PT1H",
+              "DuplicateDetectionHistoryTimeWindow": "PT20S",
+              "RequiresDuplicateDetection": false
+            },
+            "Subscriptions": [
+              {
+                "Name": "subscription.1",
+                "Properties": {
+                  "DeadLetteringOnMessageExpiration": false,
+                  "DefaultMessageTimeToLive": "PT1H",
+                  "LockDuration": "PT1M",
+                  "MaxDeliveryCount": 3,
+                  "ForwardDeadLetteredMessagesTo": "",
+                  "ForwardTo": "",
+                  "RequiresSession": false
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "Logging": {
+      "Type": "File"
+    }
+  }
+}

--- a/local/docker-compose.yml
+++ b/local/docker-compose.yml
@@ -1,0 +1,34 @@
+name: integration-hub-poc
+services:
+  emulator:
+    container_name: "servicebus-emulator"
+    image: mcr.microsoft.com/azure-messaging/servicebus-emulator:latest
+    pull_policy: always
+    volumes:
+      - "${CONFIG_PATH}:/ServiceBus_Emulator/ConfigFiles/Config.json"
+    ports:
+      - "5672:5672"
+    environment:
+      SQL_SERVER: sqledge
+      MSSQL_SA_PASSWORD: "${MSSQL_SA_PASSWORD}"
+      ACCEPT_EULA: ${ACCEPT_EULA}
+    depends_on:
+      - sqledge
+    networks:
+      integration-hub-poc:
+        aliases:
+          - "sb-emulator"
+  sqledge:
+        container_name: "sqledge"
+        image: "mcr.microsoft.com/azure-sql-edge:latest"
+        networks:
+          integration-hub-poc:
+            aliases:
+              - "sqledge"
+        environment:
+          ACCEPT_EULA: ${ACCEPT_EULA}
+          MSSQL_SA_PASSWORD: "${MSSQL_SA_PASSWORD}"
+
+networks:
+  integration-hub-poc:
+


### PR DESCRIPTION
- Add `.env` file with configuration variables
- Update main `README.md` with link to instructions to run the POC locally
- Add `docker-compose.yml` to set up Service Bus emulator and SQL Edge
- Include `ServiceBusEmulatorConfig.json` for emulator configuration
- Add `local/README.md` with setup and usage instructions