### PR TITLE
Route messages based on message type, sending application or specialty

### DIFF
--- a/local/ServiceBusEmulatorConfig.json
+++ b/local/ServiceBusEmulatorConfig.json
@@ -115,7 +115,54 @@
                   "ForwardTo": "dhcw-integration-hub-poc-docker-sender",
                   "RequiresSession": false
                 }
-              }
+              },
+              {
+                "Name": "dhcw-integration-hub-poc-docker-hl7senders-A40-sub",
+                "Properties": {
+                  "DeadLetteringOnMessageExpiration": false,
+                  "DefaultMessageTimeToLive": "PT1H",
+                  "LockDuration": "PT1M",
+                  "MaxDeliveryCount": 3,
+                  "ForwardDeadLetteredMessagesTo": "",
+                  "ForwardTo": "",
+                  "RequiresSession": false
+                },
+                "Rules": [
+                  {
+                    "Name": "sql-filter-102",
+                    "Properties": {
+                      "FilterType": "Sql",
+                      "SqlFilter": {
+                        "SqlExpression": "hl7.messageType = 'ADT^A40'"
+                      }
+                    }
+                  }
+                ]
+
+              },
+              {
+                "Name": "dhcw-inthubpoc-docker-hl7senders-sys102-sub",
+                "Properties": {
+                  "DeadLetteringOnMessageExpiration": false,
+                  "DefaultMessageTimeToLive": "PT1H",
+                  "LockDuration": "PT1M",
+                  "MaxDeliveryCount": 3,
+                  "ForwardDeadLetteredMessagesTo": "",
+                  "ForwardTo": "",
+                  "RequiresSession": false
+                },
+                "Rules": [
+                  {
+                    "Name": "sql-filter-102",
+                    "Properties": {
+                      "FilterType": "Sql",
+                      "SqlFilter": {
+                        "SqlExpression": "hl7.sendingApp = '102'"
+                      }
+                    }
+                  }
+                  ]
+                }
             ]
           },
           {

--- a/local/ServiceBusEmulatorConfig.json
+++ b/local/ServiceBusEmulatorConfig.json
@@ -129,7 +129,7 @@
                 },
                 "Rules": [
                   {
-                    "Name": "sql-filter-102",
+                    "Name": "sql-filter-A40",
                     "Properties": {
                       "FilterType": "Sql",
                       "SqlFilter": {
@@ -153,7 +153,7 @@
                 },
                 "Rules": [
                   {
-                    "Name": "sql-filter-102",
+                    "Name": "sql-filter-sender-102",
                     "Properties": {
                       "FilterType": "Sql",
                       "SqlFilter": {

--- a/local/ServiceBusEmulatorConfig.json
+++ b/local/ServiceBusEmulatorConfig.json
@@ -133,7 +133,7 @@
                     "Properties": {
                       "FilterType": "Sql",
                       "SqlFilter": {
-                        "SqlExpression": "hl7.messageType = 'ADT^A40'"
+                        "SqlExpression": "user.hl7MessageType = 'ADT^A40'"
                       }
                     }
                   }
@@ -157,7 +157,7 @@
                     "Properties": {
                       "FilterType": "Sql",
                       "SqlFilter": {
-                        "SqlExpression": "hl7.sendingApp = '102'"
+                        "SqlExpression": "user.hl7SendingApp = '102'"
                       }
                     }
                   }

--- a/message-bus-lib/src/main/java/wales/nhs/dhcw/msgbus/MessageSenderClient.java
+++ b/message-bus-lib/src/main/java/wales/nhs/dhcw/msgbus/MessageSenderClient.java
@@ -6,6 +6,9 @@ import com.azure.messaging.servicebus.ServiceBusSenderClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Collections;
+import java.util.Map;
+
 public class MessageSenderClient implements AutoCloseable {
 
     private static final Logger logger = LoggerFactory.getLogger(MessageSenderClient.class);
@@ -18,13 +21,23 @@ public class MessageSenderClient implements AutoCloseable {
         this.topicName = topicName;
     }
 
-    public void sendMessage(BinaryData message) {
-        serviceBusSenderClient.sendMessage(new ServiceBusMessage(message));
+    public void sendMessage(BinaryData messageData) {
+        sendMessage(messageData, Collections.emptyMap());
+    }
+
+    public void sendMessage(BinaryData messageData,  Map<String, String> customProperties) {
+        ServiceBusMessage message = new ServiceBusMessage(messageData);
+        message.getApplicationProperties().putAll(customProperties);
+        serviceBusSenderClient.sendMessage(message);
         logger.debug("Message sent successfully to topic: {}", topicName);
     }
 
-    public void sendMessage(String message) {
-        sendMessage(BinaryData.fromString(message));
+    public void sendMessage(String messageData) {
+        sendMessage(BinaryData.fromString(messageData));
+    }
+
+    public void sendMessage(String messageData, Map<String, String> customProperties) {
+        sendMessage(BinaryData.fromString(messageData), customProperties);
     }
 
     @Override

--- a/wpas-hl7-translator/src/main/java/wales/nhs/dhcw/inthub/wpasHl7/CustomPropertiesBuilder.java
+++ b/wpas-hl7-translator/src/main/java/wales/nhs/dhcw/inthub/wpasHl7/CustomPropertiesBuilder.java
@@ -6,12 +6,15 @@ import ca.uhn.hl7v2.model.v251.segment.MSH;
 import ca.uhn.hl7v2.model.v251.segment.PV1;
 
 import java.util.HashMap;
+import java.util.Set;
 
 public class CustomPropertiesBuilder {
 
-    public static final String MESSAGE_TYPE_PROPERTY = "hl7.messageType";
-    public static final String SENDING_APPLICATION_PROPERTY = "hl7.sendingApp";
-    public static final String SPECIALTY_PROPERTY = "hl7.specialty";
+    public static final String MESSAGE_TYPE_PROPERTY = "hl7MessageType";
+    public static final String SENDING_APPLICATION_PROPERTY = "hl7SendingApp";
+    public static final String SPECIALTY_PROPERTY = "hl7Specialty";
+
+    private static final String PATIENT_VISIT_SEGMENT = "PV1";
 
     public HashMap<String, String> buildCustomProperties(AbstractMessage hl7Data) throws HL7Exception {
         MSH msh = (MSH) hl7Data.get("MSH");
@@ -23,11 +26,17 @@ public class CustomPropertiesBuilder {
         customProperties.put(SENDING_APPLICATION_PROPERTY,
                 msh.getMsh3_SendingApplication().getNamespaceID().getValue()
         );
-        var pv1 = (PV1)hl7Data.get("PV1");
-        String specialty = pv1.getPv110_HospitalService().getValue();
-        if (specialty != null) {
-            customProperties.put(SPECIALTY_PROPERTY, specialty);
+        if (messageContains(hl7Data, PATIENT_VISIT_SEGMENT)) {
+            var pv1 = (PV1)hl7Data.get("PV1");
+            String specialty = pv1.getPv110_HospitalService().getValue();
+            if (specialty != null) {
+                customProperties.put(SPECIALTY_PROPERTY, specialty);
+            }
         }
         return customProperties;
+    }
+
+    private boolean messageContains(AbstractMessage message, String segmentName) {
+        return Set.of(message.getNames()).contains(segmentName);
     }
 }

--- a/wpas-hl7-translator/src/main/java/wales/nhs/dhcw/inthub/wpasHl7/CustomPropertiesBuilder.java
+++ b/wpas-hl7-translator/src/main/java/wales/nhs/dhcw/inthub/wpasHl7/CustomPropertiesBuilder.java
@@ -6,6 +6,7 @@ import ca.uhn.hl7v2.model.v251.segment.MSH;
 import ca.uhn.hl7v2.model.v251.segment.PV1;
 
 import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 
 public class CustomPropertiesBuilder {
@@ -16,7 +17,7 @@ public class CustomPropertiesBuilder {
 
     private static final String PATIENT_VISIT_SEGMENT = "PV1";
 
-    public HashMap<String, String> buildCustomProperties(AbstractMessage hl7Data) throws HL7Exception {
+    public Map<String, String> buildCustomProperties(AbstractMessage hl7Data) throws HL7Exception {
         MSH msh = (MSH) hl7Data.get("MSH");
 
         var customProperties = new HashMap<String, String>();

--- a/wpas-hl7-translator/src/main/java/wales/nhs/dhcw/inthub/wpasHl7/CustomPropertiesBuilder.java
+++ b/wpas-hl7-translator/src/main/java/wales/nhs/dhcw/inthub/wpasHl7/CustomPropertiesBuilder.java
@@ -1,0 +1,33 @@
+package wales.nhs.dhcw.inthub.wpasHl7;
+
+import ca.uhn.hl7v2.HL7Exception;
+import ca.uhn.hl7v2.model.AbstractMessage;
+import ca.uhn.hl7v2.model.v251.segment.MSH;
+import ca.uhn.hl7v2.model.v251.segment.PV1;
+
+import java.util.HashMap;
+
+public class CustomPropertiesBuilder {
+
+    public static final String MESSAGE_TYPE_PROPERTY = "hl7.messageType";
+    public static final String SENDING_APPLICATION_PROPERTY = "hl7.sendingApp";
+    public static final String SPECIALTY_PROPERTY = "hl7.specialty";
+
+    public HashMap<String, String> buildCustomProperties(AbstractMessage hl7Data) throws HL7Exception {
+        MSH msh = (MSH) hl7Data.get("MSH");
+
+        var customProperties = new HashMap<String, String>();
+        var messageType = msh.getMsh9_MessageType().getMsg1_MessageCode() + "^"
+                + msh.getMsh9_MessageType().getMsg2_TriggerEvent();
+        customProperties.put(MESSAGE_TYPE_PROPERTY, messageType);
+        customProperties.put(SENDING_APPLICATION_PROPERTY,
+                msh.getMsh3_SendingApplication().getNamespaceID().getValue()
+        );
+        var pv1 = (PV1)hl7Data.get("PV1");
+        String specialty = pv1.getPv110_HospitalService().getValue();
+        if (specialty != null) {
+            customProperties.put(SPECIALTY_PROPERTY, specialty);
+        }
+        return customProperties;
+    }
+}

--- a/wpas-hl7-translator/src/main/java/wales/nhs/dhcw/inthub/wpasHl7/Main.java
+++ b/wpas-hl7-translator/src/main/java/wales/nhs/dhcw/inthub/wpasHl7/Main.java
@@ -26,6 +26,7 @@ public final class Main {
         WpasXmlParser parser = new WpasXmlParser();
         WpasHl7Translator translator = new WpasHl7Translator(new DateTimeProvider(Hl7DateFormatProvider.getDateTimeFormatter()));
         Hl7Encoder hl7Encoder = new Hl7Encoder();
+        CustomPropertiesBuilder propertiesBuilder = new CustomPropertiesBuilder();
 
         Runtime.getRuntime().addShutdownHook(new Thread(() -> {
             LOGGER.info("Shutting down the translator.");
@@ -46,7 +47,8 @@ public final class Main {
                         var mainData = parser.parse(messageBody.toStream());
                         var hl7Data = translator.translate(mainData);
                         var serializedHl7 = hl7Encoder.encode(hl7Data);
-                        senderClient.sendMessage(serializedHl7);
+                        var customProperties = propertiesBuilder.buildCustomProperties(hl7Data);
+                        senderClient.sendMessage(serializedHl7, customProperties);
 
                     } catch (Exception e) {
                         LOGGER.error("WPAS message translation error", e);
@@ -58,5 +60,7 @@ public final class Main {
             }
         }
     }
+
+
 }
 

--- a/wpas-hl7-translator/src/test/java/wales/nhs/dhcw/inthub/wpasHl7/CustomPropertiesBuilderTest.java
+++ b/wpas-hl7-translator/src/test/java/wales/nhs/dhcw/inthub/wpasHl7/CustomPropertiesBuilderTest.java
@@ -4,6 +4,7 @@ import ca.uhn.hl7v2.HL7Exception;
 import ca.uhn.hl7v2.model.AbstractMessage;
 import ca.uhn.hl7v2.model.v251.message.ADT_A01;
 import ca.uhn.hl7v2.model.v251.message.ADT_A05;
+import ca.uhn.hl7v2.model.v251.message.ADT_A39;
 import ca.uhn.hl7v2.model.v251.segment.MSH;
 import ca.uhn.hl7v2.model.v251.segment.PV1;
 import org.junit.jupiter.api.Test;
@@ -41,17 +42,17 @@ class CustomPropertiesBuilderTest {
     void routingPropertiesAreSetWithoutSpecialty() throws Exception {
         // Arrange
         var messageTypeCode = "ADT";
-        var messageTypeEvent = "A01";
+        var messageTypeEvent = "A40";
         var sendingApplication = "109";
 
-        var hl7Message = new ADT_A05();
+        var hl7Message = new ADT_A39();
         buildHl7Message(hl7Message, messageTypeCode, messageTypeEvent, sendingApplication, null);
 
         // Act
         var result = builder.buildCustomProperties(hl7Message);
 
         // Assert
-        assertEquals("ADT^A01" ,result.get(CustomPropertiesBuilder.MESSAGE_TYPE_PROPERTY));
+        assertEquals("ADT^A40" ,result.get(CustomPropertiesBuilder.MESSAGE_TYPE_PROPERTY));
         assertEquals(sendingApplication, result.get(CustomPropertiesBuilder.SENDING_APPLICATION_PROPERTY));
         assertFalse(result.containsKey(CustomPropertiesBuilder.SPECIALTY_PROPERTY));
     }

--- a/wpas-hl7-translator/src/test/java/wales/nhs/dhcw/inthub/wpasHl7/CustomPropertiesBuilderTest.java
+++ b/wpas-hl7-translator/src/test/java/wales/nhs/dhcw/inthub/wpasHl7/CustomPropertiesBuilderTest.java
@@ -1,0 +1,72 @@
+package wales.nhs.dhcw.inthub.wpasHl7;
+
+import ca.uhn.hl7v2.HL7Exception;
+import ca.uhn.hl7v2.model.AbstractMessage;
+import ca.uhn.hl7v2.model.v251.message.ADT_A01;
+import ca.uhn.hl7v2.model.v251.message.ADT_A05;
+import ca.uhn.hl7v2.model.v251.segment.MSH;
+import ca.uhn.hl7v2.model.v251.segment.PV1;
+import org.junit.jupiter.api.Test;
+import wales.nhs.dhcw.inthub.wpasHl7.mapping.HL7Constants;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+
+class CustomPropertiesBuilderTest {
+
+    private CustomPropertiesBuilder builder = new CustomPropertiesBuilder();
+
+    @Test
+    void routingPropertiesAreSet() throws Exception {
+        // Arrange
+        var messageTypeCode = "ADT";
+        var messageTypeEvent = "A01";
+        var sendingApplication = "109";
+        var specialty = "Spec";
+
+        var hl7Message = new ADT_A01();
+        buildHl7Message(hl7Message, messageTypeCode, messageTypeEvent, sendingApplication, specialty);
+
+        // Act
+        var result = builder.buildCustomProperties(hl7Message);
+
+        // Assert
+        assertEquals("ADT^A01" ,result.get(CustomPropertiesBuilder.MESSAGE_TYPE_PROPERTY));
+        assertEquals(sendingApplication, result.get(CustomPropertiesBuilder.SENDING_APPLICATION_PROPERTY));
+        assertEquals(specialty, result.get(CustomPropertiesBuilder.SPECIALTY_PROPERTY));
+    }
+
+    @Test
+    void routingPropertiesAreSetWithoutSpecialty() throws Exception {
+        // Arrange
+        var messageTypeCode = "ADT";
+        var messageTypeEvent = "A01";
+        var sendingApplication = "109";
+
+        var hl7Message = new ADT_A05();
+        buildHl7Message(hl7Message, messageTypeCode, messageTypeEvent, sendingApplication, null);
+
+        // Act
+        var result = builder.buildCustomProperties(hl7Message);
+
+        // Assert
+        assertEquals("ADT^A01" ,result.get(CustomPropertiesBuilder.MESSAGE_TYPE_PROPERTY));
+        assertEquals(sendingApplication, result.get(CustomPropertiesBuilder.SENDING_APPLICATION_PROPERTY));
+        assertFalse(result.containsKey(CustomPropertiesBuilder.SPECIALTY_PROPERTY));
+    }
+
+    private static void buildHl7Message(AbstractMessage hl7Message, String messageTypeCode, String messageTypeEvent, String sendingApplication, String specialty) throws HL7Exception {
+        var msh = (MSH)hl7Message.get("MSH");
+        msh.getFieldSeparator().setValue(HL7Constants.PIPE_LINE);
+        msh.getEncodingCharacters().setValue(HL7Constants.ENCODING_CHAR);
+        msh.getMsh9_MessageType().getMsg1_MessageCode().setValue(messageTypeCode);
+        msh.getMsh9_MessageType().getMsg2_TriggerEvent().setValue(messageTypeEvent);
+        msh.getMsh3_SendingApplication().getNamespaceID().setValue(sendingApplication);
+
+        if (specialty != null) {
+            var pv1 = (PV1)hl7Message.get("PV1");
+            pv1.getPv110_HospitalService().setValue(specialty);
+        }
+    }
+}


### PR DESCRIPTION
Setting application properties on translated messages to support routing:
- hl7MessageType
- hl7SendingApp
- hl7Specialty

Example filter in local environment based on those properties.